### PR TITLE
Adds alternative asset checker

### DIFF
--- a/includes/grid-builder/class-gbf.php
+++ b/includes/grid-builder/class-gbf.php
@@ -216,7 +216,7 @@ class BS3_Grid_Builder_GBF{
 	// Admin scripts
 	public function scripts( $hook_suffix ){
 		global $post_type;
-		if( ! post_type_supports( $post_type, 'bs3_grid_builder' ) ):
+		if( in_array( $post_type, get_option('bs3_grid_builder_post_types_option_name') ) ):
 			return;
 		endif;
 		


### PR DESCRIPTION
This only loads the scripts on post types that are set in the builder. I was getting an error on the post post type edit page:

```javascript
bs3-grid-builder-item.js:64 Uncaught TypeError: Cannot read property 'content_css' of undefined
```